### PR TITLE
Archiving repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS Cryptographic Material Providers Library for .NET 
 
+**Important** Development of this project has moved from a per language repository to a monorepo here: https://github.com/aws/aws-cryptographic-material-providers-library
+
 The AWS Cryptographic Material Providers Library abstracts lower level cryptographic materials management of encryption and decryption materials.
 It uses cryptographic best practices to protect the data keys that protect your data.
 The data key is protected with a key encryption key called a *wrapping key*.


### PR DESCRIPTION
Updating the readme to point to https://github.com/aws/aws-cryptographic-material-providers-library where development is progressing now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

